### PR TITLE
Added base console app with Dotenv loading

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -1,0 +1,1 @@
+CLOCKIFY_API_KEY='Key from https://clockify.me/user/settings'

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /vendor/
+.env

--- a/app
+++ b/app
@@ -1,0 +1,1 @@
+src/application.php

--- a/src/application.php
+++ b/src/application.php
@@ -1,0 +1,23 @@
+#!/usr/bin/env php
+<?php
+
+require __DIR__ . '/../vendor/autoload.php';
+
+use Symfony\Component\Console\Application;
+
+// Load Dotenv
+$dotenv = Dotenv\Dotenv::createImmutable(__DIR__ . '/..');
+$dotenv->load();
+
+// Require API key
+$dotenv->required('CLOCKIFY_API_KEY')->notEmpty();
+
+$application = new Application();
+
+// Set up app information
+$application->setName('Clockify CLI Tool');
+$application->setVersion('0.0.1');
+
+// ... register commands
+
+$application->run();


### PR DESCRIPTION
This based Symfony console app is just the bare bones setup before
adding commands. This sets the app, makes it executable with `./app`,
sets the name and versioon, and loads Dotenv ensuring `CLOCKIFY_API_KEY`
is set and not empty.