### PR TITLE
Added Automated Setup and Timer Start command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,11 @@
             "email": "contact@grantlucas.com"
         }
     ],
+    "autoload": {
+        "psr-4": {
+            "App\\": "src/"
+        }
+    },
     "scripts": {
         "cs": [
             "./vendor/bin/phpcs"

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -5,7 +5,9 @@
 
     <file>src</file>
 
-    <rule ref="PSR12"/>
+    <rule ref="PSR12">
+        <exclude name="Generic.Files.LineLength.TooLong"/>
+    </rule>
 
     <!-- Some Squiz nice to have formatting -->
     <!-- Specifically turn ON checking for extra whitespace in empty lines -->

--- a/src/Commands/BaseCommand.php
+++ b/src/Commands/BaseCommand.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Commands;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Output\ConsoleOutput;
+use Symfony\Component\Console\Output\ConsoleSectionOutput;
+
+/**
+ * Class BaseCommand
+ * @author Grant Lucas
+ */
+class BaseCommand extends Command
+{
+    /**
+     * Create Section
+     *
+     * Create a console output section. This is mainly to satisfy static
+     * analysis as OutputInterface doesn't have the section method but
+     * ConsoleOutput does. Since this app is primarily console based, we can
+     * work around it here.
+     *
+     */
+    protected function createSection($output): ConsoleSectionOutput
+    {
+        if ($output instanceof ConsoleOutput) {
+            return $output->section();
+        }
+
+        throw new \InvalidArgumentException('This should never be hit');
+    }
+}

--- a/src/Commands/SetupCommand.php
+++ b/src/Commands/SetupCommand.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace App\Commands;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ChoiceQuestion;
+use Symfony\Component\Console\Input\InputOption;
+use JDecool\Clockify\Client as ClockifyClient;
+
+class SetupCommand extends BaseCommand
+{
+    protected static $defaultName = 'setup';
+
+    protected $clockifyClient;
+
+    public function __construct(ClockifyClient $clockifyClient)
+    {
+        $this->clockifyClient = $clockifyClient;
+
+        parent::__construct();
+    }
+
+    protected function configure()
+    {
+        // Basic description and help text
+        $this
+            ->setDescription('Setup Clockify CLI App')
+            ->setHelp('This will aid in setting up the current instance to connect with the correct workspace.');
+
+        $this->addOption(
+            'automated',
+            null,
+            InputOption::VALUE_NONE,
+            'Whether this is automated setup'
+        );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        // Detect if we're in automated setup
+        $automatedSetup = $input->getOption('automated');
+
+        if ($automatedSetup) {
+            $output->writeln([
+                'No <comment>CLOCKIFY_WORKSPACE</comment> ENV var was detected.',
+                '',
+                'The following setup will help determine what to set for the future.',
+                'This application <options=bold,underscore>requires</> a Workspace ID to be set to function properly.',
+                ''
+            ]);
+        }
+
+        $loadingSection = $this->createSection($output);
+        $loadingSection->writeln('<info>Fetching workspances from Clockify...</info>');
+
+        // Load all the workspaces and prsent a list for choice
+        $workspaceData = $this->clockifyClient->get('workspaces');
+        $workspaces = array_column($workspaceData, 'name', 'id');
+
+        // Clear loading message
+        $loadingSection->clear();
+
+        // Error out if we have no workspaces
+        if (empty($workspaces)) {
+            $output->writeln('<error>No workspaces found</error>');
+            return Command::FAILURE;
+        }
+
+        // If there's only one workspace found, set that as the selected workspace
+        if (count($workspaces) === 1) {
+            $workspaceID = array_key_first($workspaces);
+            $output->writeln("<comment>Only one workspace ({$workspaces[$workspaceID]}) found in account...</comment>");
+            $selectedWorkspaceID = array_key_first($workspaces);
+        } else {
+            // Prompt user to choose a workspace when there are multiples
+            $questionHelper = $this->getHelper('question');
+            $question = new ChoiceQuestion(
+                'Select which workspace to use',
+                $workspaces
+            );
+
+            // Ask and store the workspace ID selected
+            $selectedWorkspaceID = $questionHelper->ask($input, $output, $question);
+        }
+
+        $output->writeln([
+            '',
+            'Add the following Workspace ID to your `.env` or Environment:',
+            "<comment>CLOCKIFY_WORKSPACE='{$selectedWorkspaceID}'</comment>",
+            '',
+            <<<TEXT
+Once added, you should not be prompted for setup again. If you wish to change
+workspaces, simply remove this ENV variable or run this setup command
+manually to see valid options to set in your environment.
+TEXT
+        ]);
+
+        // TODO: Get the current user and prompt to store that
+        // $workspaceData = $this->clockifyClient->get('user');
+        // TODO: In here, detect _which_ key is missing and only show the
+        // relevant information or make that input options for what to prompt
+        // for
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Commands/TimerStartCommand.php
+++ b/src/Commands/TimerStartCommand.php
@@ -1,0 +1,271 @@
+<?php
+
+namespace App\Commands;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Question\ChoiceQuestion;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+use JDecool\Clockify\Client as ClockifyClient;
+use App\Models\Item;
+
+class TimerStartCommand extends BaseCommand
+{
+    protected static $defaultName = 'timer:start';
+
+    protected $clockifyClient;
+
+    public function __construct(ClockifyClient $clockifyClient)
+    {
+        $this->clockifyClient = $clockifyClient;
+
+        parent::__construct();
+    }
+
+    protected function configure()
+    {
+        // Basic description and help text
+        $this
+            ->setDescription('Start/continue a timer')
+            ->setHelp('Start or continue a timer, setting the project and optional tags.');
+
+        // Input arguments
+        $this
+            ->addArgument(
+                'description',
+                InputArgument::REQUIRED,
+                'The description for this timer.'
+            );
+
+        // Input options
+        $this
+            // Project option
+            ->addOption(
+                'project',
+                'p',
+                InputOption::VALUE_REQUIRED,
+                'The project to assign this timer to'
+            )
+
+            // Tags Option
+            // TODO: Make this support multiple tags later
+            ->addOption(
+                'tag',
+                't',
+                InputOption::VALUE_OPTIONAL,
+                'Tag to assign to this timer',
+                false
+            )
+            ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        // Process and select a project
+        try {
+            $selectedProject = $this->selectProject($input, $output);
+        } catch (\Exception $e) {
+            $output->writeln("<error>{$e->getMessage()}</error>");
+            return Command::FAILURE;
+        }
+
+        // Output what project was selected
+        $output->writeln([
+            '',
+            "Selected project: <comment>{$selectedProject->getName()}</comment>",
+        ]);
+
+        // Process and select tag if tag input param exists at all
+        $tagSet = $input->getOption('tag');
+        $selectedTag = null;
+        if ($tagSet !== false) {
+            try {
+                $selectedTag = $this->selectTag($input, $output);
+            } catch (\Exception $e) {
+                $output->writeln("<error>{$e->getMessage()}</error>");
+                return Command::FAILURE;
+            }
+
+            // Output what tag was selected
+            $output->writeln([
+                '',
+                "Selected tag: <comment>{$selectedTag->getName()}</comment>",
+            ]);
+        }
+
+        // Build request to send to Clockify to start a timer starting now
+        $entryData = [
+            'start' => date("Y-m-d\TH:i:s\Z"),
+            'description' => $input->getArgument('description'),
+            'projectId' => $selectedProject->getId(),
+        ];
+
+        if (!empty($selectedTag)) {
+            $entryData['tagIds'] = [];
+            $entryData['tagIds'][] = $selectedTag->getId();
+        }
+
+        try {
+            $output->writeln('<info>Starting Timer</info>');
+
+            // POST data to Clockify and watch for response
+            $createdEntry = $this->clockifyClient->post("/workspaces/{$_ENV['CLOCKIFY_WORKSPACE']}/time-entries", $entryData);
+
+            $output->writeln('<info>Timer started</info>');
+            return Command::SUCCESS;
+        } catch (\Exception $e) {
+            $output->writeln([
+                '',
+                "<fg=red>Error:</>",
+                $e->getMessage()
+            ]);
+            return Command::FAILURE;
+        }
+    }
+
+    /**
+     * Select Project
+     *
+     * Perform the needed queries and selections for a project
+     *
+     * @return Item A processed item consisting of an ID and name
+     * @throws Exception When no projects are found
+     */
+    private function selectProject(InputInterface $input, OutputInterface $output): Item
+    {
+        $questionHelper = $this->getHelper('question');
+
+        $loadingSection = $this->createSection($output);
+        $loadingSection->writeln('<info>Fetching Projects from Clockify...</info>');
+
+        // Load projects
+        $projectsRoute = "workspaces/{$_ENV['CLOCKIFY_WORKSPACE']}/projects";
+
+        $queryParams = [];
+
+        // If project is provided, add name search when loading projects
+        $desiredProject = $input->getOption('project');
+
+        if ($desiredProject) {
+            $queryParams['name'] = $desiredProject;
+        }
+
+        if (!empty($queryParams)) {
+            $projectsRoute .= '?' . http_build_query($queryParams);
+        }
+
+        $projectsData = $this->clockifyClient->get($projectsRoute);
+        $projects = array_column($projectsData, 'name', 'id');
+
+        // Clear loading message
+        $loadingSection->clear();
+
+        // Error out if we have no project to work with
+        if (empty($projects)) {
+            throw new \Exception('No projects found');
+        }
+
+
+        if (count($projects) > 1) {
+            // If we have multiple projects returned, show a selection list
+            $projectQuestion = new ChoiceQuestion(
+                'Select which project to use',
+                $projects
+            );
+
+            $selectedProjectID = $questionHelper->ask($input, $output, $projectQuestion);
+        } else {
+            // Single project found, use it's ID
+            $selectedProjectID = array_key_first($projects);
+
+
+            $confirmationQuestion = new ConfirmationQuestion(
+                "One project found: <comment>{$projects[$selectedProjectID]}</comment>. Do you wish to continue? (y/N): ",
+                false,
+            );
+
+            // Ask if we want to continue. If no, exit the process so the user
+            // can start over
+            if (!$questionHelper->ask($input, $output, $confirmationQuestion)) {
+                throw new \Exception('Aborted');
+            }
+        }
+
+        return new Item($selectedProjectID, $projects[$selectedProjectID]);
+    }
+
+    /**
+     * Select Tag
+     *
+     * Perform the needed queries and user interaction to set a tag
+     *
+     * NOTE: This is currently limted to one tag for simplicity. In the future
+     * we should be able to select and set multiple tags at once.
+     *
+     * @return Item A processed item consisting of an ID and name
+     * @throws Exception When no tag is found by the desired input
+     */
+    private function selectTag(InputInterface $input, OutputInterface $output): Item
+    {
+        $questionHelper = $this->getHelper('question');
+
+        $loadingSection = $this->createSection($output);
+        $loadingSection->writeln('<info>Fetching Tags from Clockify...</info>');
+
+        // Load tags
+        $tagsRoute = "workspaces/{$_ENV['CLOCKIFY_WORKSPACE']}/tags";
+
+        $queryParams = [];
+
+        // If tag is provided, add name search when loading tags
+        $desiredTag = $input->getOption('tag');
+
+        if ($desiredTag) {
+            $queryParams['name'] = $desiredTag;
+        }
+
+        if (!empty($queryParams)) {
+            $tagsRoute .= '?' . http_build_query($queryParams);
+        }
+
+        $tagsData = $this->clockifyClient->get($tagsRoute);
+        $tags = array_column($tagsData, 'name', 'id');
+
+        // Clear loading message
+        $loadingSection->clear();
+
+        // Error out if we have no tag to work with
+        if (empty($tags)) {
+            throw new \Exception('No tags found');
+        }
+
+        if (count($tags) > 1) {
+            // If we have multiple tags returned, show a selection list
+            $tagQuestion = new ChoiceQuestion(
+                'Select which tag to use',
+                $tags
+            );
+
+            $selectedTagID = $questionHelper->ask($input, $output, $tagQuestion);
+        } else {
+            // Single tag found, use it's ID
+            $selectedTagID = array_key_first($tags);
+
+            $confirmationQuestion = new ConfirmationQuestion(
+                "One tag found: <comment>{$tags[$selectedTagID]}</comment>. Do you wish to continue? (y/N): ",
+                false,
+            );
+
+            // Ask if we want to continue. If no, exit the process so the user
+            // can start over
+            if (!$questionHelper->ask($input, $output, $confirmationQuestion)) {
+                throw new \Exception('Aborted');
+            }
+        }
+
+        return new Item($selectedTagID, $tags[$selectedTagID]);
+    }
+}

--- a/src/Models/Item.php
+++ b/src/Models/Item.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Models;
+
+/**
+ * Class Item
+ * @author Grant Lucas
+ */
+class Item
+{
+    /**
+     * @var string $id
+     */
+    private $id = '';
+
+    /**
+     * @var string $name
+     */
+    private $name = '';
+
+    /**
+     * @param string $id
+     * @param string $name
+     */
+    public function __construct(string $id, string $name)
+    {
+        $this->id = $id;
+        $this->name = $name;
+    }
+
+    /**
+     * Getter for id
+     *
+     * @return string
+     */
+    public function getId(): string
+    {
+        return $this->id ;
+    }
+
+    /**
+     * Getter for name
+     *
+     * @return string
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+}

--- a/src/application.php
+++ b/src/application.php
@@ -4,6 +4,8 @@
 require __DIR__ . '/../vendor/autoload.php';
 
 use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\ConsoleOutput;
 
 // Load Dotenv
 $dotenv = Dotenv\Dotenv::createImmutable(__DIR__ . '/..');
@@ -12,12 +14,43 @@ $dotenv->load();
 // Require API key
 $dotenv->required('CLOCKIFY_API_KEY')->notEmpty();
 
+// Build out the Clockify PHP Client to inject into commands
+
+$builder = new JDecool\Clockify\ClientBuilder();
+$clockifyClient = $builder->createClientV1($_ENV['CLOCKIFY_API_KEY']);
+
 $application = new Application();
 
 // Set up app information
 $application->setName('Clockify CLI Tool');
 $application->setVersion('0.0.1');
 
-// ... register commands
+// Register Setup command
+$application->add(new App\Commands\SetupCommand($clockifyClient));
+
+// Check if we have a defined workspace and, if not, force the run of the setup command
+if (empty($_ENV['CLOCKIFY_WORKSPACE'])) {
+    // Only show automated setup if certain helper options are being used
+    if (
+        !in_array('--help', $_SERVER['argv'])
+        && !in_array('-h', $_SERVER['argv'])
+        && !in_array('-V', $_SERVER['argv'])
+        && !in_array('--version', $_SERVER['argv'])
+    ) {
+        $setupCommand = $application->find('setup');
+        $arguments = [
+            '--automated' => true,
+        ];
+
+        $setupInput = new ArrayInput($arguments);
+        $setupCommand->run($setupInput, new ConsoleOutput());
+
+        // Exit early to prevent the rest of the app from showing
+        return;
+    }
+}
+
+// Register Timer Start command
+$application->add(new App\Commands\TimerStartCommand($clockifyClient));
 
 $application->run();


### PR DESCRIPTION
Resolves #2

Automated Setup Command
=======================

To ensure the app is configured with the proper workspace ID, the ENV
var is checked for on app bootstrap. If it's not found, the setup
command is triggered which loads all workspaces available to the current
API key.

**If there are multiple workspaces,** a list is presented and the user
can choose. If there is only one, it's auto-selected. Once a selection
is made, the unique workspace ID is shown to the user and they're
prompted to add this to their environment.

All Clockify usage requires the use of these unique IDs so searching and
listing all workspaces in a human readable way helps bridge this gap.

Running the setup command directly can be useful should the workspace
need to be changed.

Timer Start Command
===================

One of the primary actions done many times a day is starting a timer
with a set description, required project, and optionally a tag. For both
projects and tags, a request is made to Clockify for projects and tags,
filtering down if one was provided. The user is presented with a list if
there are multiple results, or they are prompted for a confirmation to
use the single value returned.

Once a human readable choice is made, we can use the unique ID going
forwards in the request as required.

Project Option
--------------

For this tool, currently, the project is required. It can either be
passed in with `--project|-p` or, if nothing was passed, all projects
will be fetched and the user will be prompted for a choice.

Tag option
----------

If a tag is to be attached to the timer, it can be passed directly and
used in a fuzzy search, or just passing `--tag` will pull down _all_
tags and prompt for a choice. Currently only a single tag is supported
however in the future, multiple tag selections will be possible.

Base Command
============

A base command was required as the `OutputInterface` doesn't have the
`section()` method which is very useful. To satisfy static analysis,
creating a section is wrapped in a function which does a type check.